### PR TITLE
fix(clinTools.py): Parse samtools pileup only once to get the correct…

### DIFF
--- a/clinTools.py
+++ b/clinTools.py
@@ -187,7 +187,6 @@ def parsePileupLine(pileupLine):
 
     # handle insertion
     for ins in insMatch:
-        depth += 1
         insLen = int(re.findall('\+([0-9]+)', ins)[0])
         insSeq = re.findall('\+' + str(insLen) + '([ATCGNatcgn]{' + str(insLen) + '})', ins)[0]
         # clean readbase


### PR DESCRIPTION
… depth of coverage values

The current implementation of parsePileupLine() account for Indels
twice in depth calculation.

This change computes depth of coverage iterating only once on
the list of nucleotides extracting from samtools pileup.